### PR TITLE
Loosen version requirements for phpdocumentor.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "phpdocumentor/reflection-docblock": "2.0.4",
+        "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
         "clean/view": "0.1.0"
     },
     "require-dev": {


### PR DESCRIPTION
There already some projects that require no less than version 4 of phpdocumentor/reflection-docblock. It is impossible to install phpdoc-md with them at the same time.
