### PR TITLE
WIP: Update for phpDocumentor\Reflection\DocBlock v3+ (Fix #7)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
+        "phpdocumentor/reflection-docblock": "^3.0.2|^4.0",
         "clean/view": "0.1.0"
     },
     "require-dev": {

--- a/docs/BasicClass.md
+++ b/docs/BasicClass.md
@@ -105,7 +105,7 @@ written in more then one line
 
 **Return Values**
 
-`integer`
+`int`
 
 
 

--- a/docs/ExtendExtendClass.md
+++ b/docs/ExtendExtendClass.md
@@ -64,10 +64,10 @@ and to provide some background information or textual references.
 
 * `(string) $firstArgument`
 : With a *description* of this argument, these may also  
-   span multiple lines.  
+span multiple lines.  
 * `(string) $secondArgument`
 : With a *description* of this argument, these may also  
-   span multiple lines.  
+span multiple lines.  
 
 **Return Values**
 

--- a/src/ClassParser.php
+++ b/src/ClassParser.php
@@ -1,6 +1,7 @@
 <?php namespace Clean\PhpDocMd;
 
 use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\DocBlockFactory;
 use ReflectionClass;
 use ReflectionMethod;
 
@@ -10,21 +11,23 @@ class ClassParser
      * @var ReflectionClass
      */
     private $reflection;
+    private $docBlockFactory;
     private $phpAtlas;
 
     public function __construct(ReflectionClass $class)
     {
         $this->reflection = $class;
+        $this->docBlockFactory = DocBlockFactory::createInstance();
         $this->phpatlas = require(__DIR__.'/phpatlas.php');
 
     }
 
     public function getClassDescription()
     {
-        $docblock = new DocBlock($this->reflection);
+        $docblock = $this->docBlockFactory->create($this->reflection->getDocComment() ?: '/** */');
         return (object)[
-            'short' => (string)$docblock->getShortDescription(),
-            'long' => (string)$docblock->getLongDescription(),
+            'short' => (string)$docblock->getSummary(),
+            'long' => (string)$docblock->getDescription(),
         ];
     }
 
@@ -55,12 +58,12 @@ class ClassParser
 
     private function getMethodDetails($method)
     {
-        $docblock = new DocBlock($method);
+        $docblock = $this->docBlockFactory->create($method->getDocComment() ?: '/** */');
 
-        if ($docblock->getShortDescription()) {
+        if ($docblock->getSummary()) {
             $data = [
-                'shortDescription' => $docblock->getShortDescription(),
-                'longDescription' => $docblock->getLongDescription(),
+                'shortDescription' => $docblock->getSummary(),
+                'longDescription' => $docblock->getDescription(),
                 'argumentsList' => $this->retrieveParams($docblock->getTagsByName('param')),
                 'argumentsDescription' => $this->retrieveParamsDescription($docblock->getTagsByName('param')),
                 'returnValue' => $this->retrieveTagData($docblock->getTagsByName('return')),
@@ -104,7 +107,7 @@ class ClassParser
         foreach ($params as $param) {
             $data[] = (object)[
                 'desc' => $param->getDescription(),
-                'type' => $param->getTypes(),
+                'type' => $param->getType(),
             ];
         }
         return $data;
@@ -114,7 +117,7 @@ class ClassParser
     {
         $data = [];
         foreach ($params as $param) {
-            $data[] = sprintf("%s %s", join('|', $param->getTypes()), $param->getVariableName());
+            $data[] = sprintf("%s $%s", $param->getType(), $param->getVariableName());
         }
         return $data;
     }
@@ -124,9 +127,9 @@ class ClassParser
         $data = [];
         foreach ($params as $param) {
             $data[] = (object)[
-                'name' => $param->getVariableName(),
+                'name' => '$' . $param->getVariableName(),
                 'desc' => $param->getDescription(),
-                'type' => $param->getTypes(),
+                'type' => $param->getType(),
             ];
         }
         return $data;

--- a/src/ClassParser.php
+++ b/src/ClassParser.php
@@ -1,6 +1,5 @@
 <?php namespace Clean\PhpDocMd;
 
-use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\DocBlockFactory;
 use ReflectionClass;
 use ReflectionMethod;

--- a/tpl/github.class.phtml
+++ b/tpl/github.class.phtml
@@ -63,8 +63,8 @@
 `This function has no parameters.`
 <?php else : ?>
 <?php foreach ($info->argumentsDescription as $param) : ?>
-* `(<?= join('|', $param->type) ?>) <?= $param->name ?>`
-<?php if ($param->desc) : ?>
+* `(<?= $param->type ?>) <?= $param->name ?>`
+<?php if (! empty(trim($param->desc))) : ?>
 : <?= str_replace("\n", "  \n", $param->desc) ?>  
 <?php endif ?>
 <?php endforeach ?>
@@ -76,9 +76,9 @@
 `void`
 <?php else : ?>
 <?php foreach ($info->returnValue as $param) : ?>
-`<?= join('|', $param->type) ?>`
+`<?= $param->type ?>`
 
-<?php if ($param->desc) : ?>
+<?php if (! empty(trim($param->desc))) : ?>
 > <?= str_replace("\n", "  \n", $param->desc) ?>
 <?php endif ?>
 
@@ -91,8 +91,8 @@
 
 <?php foreach ($info->throwsExceptions as $param) : ?>
 
-`<?= join('|', $param->type) ?>`
-<?php if ($param->desc) : ?>
+`<?= $param->type ?>`
+<?php if (! empty(trim($param->desc))) : ?>
 > <?= str_replace("\n", "  \n", $param->desc) ?>
 <?php endif ?>
 

--- a/tpl/stash.class.phtml
+++ b/tpl/stash.class.phtml
@@ -68,8 +68,8 @@ function normalize($text)
 `This function has no parameters.`
 <?php else : ?>
 <?php foreach ($info->argumentsDescription as $param) : ?>
-* `(<?= join('|', $param->type) ?>) <?= $param->name ?>`
-<?php if ($param->desc) : ?>
+* `(<?= $param->type ?>) <?= $param->name ?>`
+<?php if (! empty(trim($param->desc))) : ?>
 : <?= str_replace("\n", "  \n", $param->desc) ?>  
 <?php endif ?>
 <?php endforeach ?>
@@ -78,9 +78,9 @@ function normalize($text)
 **Return Values**
 
 <?php foreach ($info->returnValue as $param) : ?>
-`<?= join('|', $param->type) ?>`
+`<?= $param->type ?>`
 
-<?php if ($param->desc) : ?>
+<?php if (! empty(trim($param->desc))) : ?>
 > <?= str_replace("\n", "  \n", $param->desc) ?>  
 <?php endif ?>
 
@@ -92,8 +92,8 @@ function normalize($text)
 
 <?php foreach ($info->throwsExceptions as $param) : ?>
 
-`<?= join('|', $param->type) ?>`
-<?php if ($param->desc) : ?>
+`<?= $param->type ?>`
+<?php if (! empty(trim($param->desc))) : ?>
 > <?= str_replace("\n", "  \n", $param->desc) ?>
 <?php endif ?>
 


### PR DESCRIPTION
As noted in #7, the API for phpDocumentor\Reflection\DocBlock has changed and is no longer compatible the code in this project. This PR *should* update things to work w/ phpDocumentor\Reflection\DocBlock v3+. As far as I can tell, the output for the example docs is identical with only a couple of exceptions, one of which is out of "our" control (eg, DocBlock now returns `int` instead of `integer`) and the other is just a whitespace change that is ignored in markdown anyway.

I labeled this as WIP b/c I still have some questions:
* I removed the 2.0 dependency from the `composer.json`, but I didn't commit any changes to the `composer.lock`. I'm not clear on some details of packages, but I thought it was not recommended to include `.lock` files in packages. Should I remove that, leave it as is, or update it?
* I got a composer error related to the dev dependency on `"codeclimate/php-test-reporter": "dev-master"`, but was able to resolve it by changing to `"codeclimate/php-test-reporter": "*"`. I didn't include that change in this PR because I'm not sure what that changes, and I need some guidance on what to do for it.

Thank you!

Summary of changes:
* Use DocBlockFactory to create DocBlock
* DocBlockFactory fails when a class or method has no doc block, so in that case we can use an empty doc block
* update new DocBlock API method names
* variables names no longer include the '$' by default
* types are joined with '|' by default
* empty descriptions seem to be returned as a single space