### PR TITLE
fix: Skip `InvalidTag` in parameter lists

### DIFF
--- a/src/ClassParser.php
+++ b/src/ClassParser.php
@@ -1,6 +1,7 @@
 <?php namespace Clean\PhpDocMd;
 
 use phpDocumentor\Reflection\DocBlockFactory;
+use phpDocumentor\Reflection\DocBlock\Tags\InvalidTag;
 use ReflectionClass;
 use ReflectionMethod;
 
@@ -119,6 +120,9 @@ class ClassParser
     {
         $data = [];
         foreach ($params as $param) {
+            if ($param instanceof InvalidTag) {
+                continue;
+            }
             $data[] = sprintf("%s $%s", $param->getType(), $param->getVariableName());
         }
         return $data;
@@ -128,6 +132,9 @@ class ClassParser
     {
         $data = [];
         foreach ($params as $param) {
+            if ($param instanceof InvalidTag) {
+                continue;
+            }
             $data[] = (object)[
                 'name' => '$' . $param->getVariableName(),
                 'desc' => $param->getDescription(),

--- a/src/snippets.php
+++ b/src/snippets.php
@@ -24,7 +24,7 @@ function getClassInfoParser($format, ReflectionClass $reflection) {
             $parser = new Markdown\GitHub\ClassInfo($reflection);
             break;
         default:
-            throw new \RuntimeException(sprintf("Unknow markdown format '%s'. Only 'github' or 'bitbucket' allowed. Check your .phpdoc-md config file", $config->format));
+            throw new \RuntimeException(sprintf("Unknown markdown format '%s'. Only 'github' or 'bitbucket' allowed. Check your .phpdoc-md config file", $config->format));
     }
     return $parser;
 


### PR DESCRIPTION
# Invalid doc comments should not cause `phpdoc-md` to fail with an unhandled exception.

When setting up `clean/phpdoc-md` in a GitHub Action, it failed with an unhandled exception because my coworker had a stray `;` in a doc comment after the type and before the parameter name something like:

```php
/**
 * Constructs an object
 *
 * @param array; $options options
 */
public function __construct(array $options)
```

This pull request if accepted causes `phpdoc-md` to skip over such parameters. A more complete solution would probably be to emit some sort of warning perhaps on `stderr`  indicating that an `InvalidTag` was being skipped in such and such file or class but at a glance that would be a more complicated fix.