### PR TITLE
fix: filter hard line wrapping from method summaries

### DIFF
--- a/docs/BasicClass.md
+++ b/docs/BasicClass.md
@@ -14,7 +14,7 @@ various PHPDoc tags are used.
 
 | Name | Description |
 |------|-------------|
-|[__construct](#basicclass__construct)|Constructs an object|
+|[__construct](#basicclass__construct)|Constructs an object of some specific type with certain unspoken defaults.|
 |[addValues](#basicclassaddvalues)|Adds two arguments|
 |[one](#basicclassone)|Returns one|
 
@@ -29,14 +29,15 @@ various PHPDoc tags are used.
 public __construct (array $options)
 ```
 
-Constructs an object 
+Constructs an object of some specific type with certain unspoken defaults. 
 
  
 
 **Parameters**
 
 * `(array) $options`
-: options  
+: the user's desired settings for the object being  
+created.  
 
 **Return Values**
 

--- a/example/BasicClass.php
+++ b/example/BasicClass.php
@@ -17,9 +17,11 @@ class BasicClass
     public $config;
 
     /**
-     * Constructs an object
+     * Constructs an object of some specific type with certain unspoken
+     * defaults.
      *
-     * @param array $options options
+     * @param array $options  the user's desired settings for the object being
+     *      created.
      *
      * @return void
      */

--- a/src/Markdown/ClassInfo.php
+++ b/src/Markdown/ClassInfo.php
@@ -29,7 +29,12 @@ abstract class ClassInfo extends Phtml
     public function render()
     {
         $parser = new ClassParser($this->reflectionClass);
-        $methods = $parser->getMethodsDetails();
+        $methods = [];
+        foreach ($parser->getMethodsDetails() as $methodName => $methodDetails) {
+            $methodDetails->shortDescription = $this
+                ->removeHardLineBreaks($methodDetails->shortDescription);
+            $methods[$methodName] = $methodDetails;
+        }
         ksort($methods);
 
         $this->setData(
@@ -44,5 +49,14 @@ abstract class ClassInfo extends Phtml
             ]
         );
         return parent::render();
+    }
+
+    /** Strip hard line wraps from string */
+    private function removeHardLineBreaks($text) {
+        return preg_replace(
+            ['(\n)', '( +)'],
+            [' ', ' '],
+            $text
+        );
     }
 }


### PR DESCRIPTION
My company has a policy of hard wrapping lines including doc comments. This leads to broken listing class methods when generating documentation with `phpdoc-md`. This PR if accepted filters hard line wraps from method summaries in `Clean\PhpDocMd\Markdown\ClassInfo` which feels to me as if it is the correct place given existing separation of responsibilities. This change is sufficient for the code bases I work with though I could foresee it being insufficient for others. Included is also a change to the example `BasicClass` showing the issue is resolved.