### PR TITLE
Add YAML validation to bootstrap GitHub Workflows

### DIFF
--- a/.github/workflows/validate_yaml.yaml
+++ b/.github/workflows/validate_yaml.yaml
@@ -1,0 +1,20 @@
+# yamllint disable rule:line-length
+
+name: YAML Validation
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  validate-yaml:
+    name: Validate YAML
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run YAML linter
+        run: |
+          find . -path \*/vendor -prune -false -o -name \*.y*ml | xargs yamllint -d relaxed


### PR DESCRIPTION
This PR adds a simple YAML validation workflow.

- This thing with GitHib workflows they won't run on PRs even if you add them there unless there's a single workflow already. 
- It is also worth nothing that GitHub won't fail the CI if YAML doesn't validate: it won't simply run the faulty workflow.

This makes this particular workflow essential.

