### PR TITLE
Fixes PHP 8.1 E_DEPRECATED in GitHub Template

### DIFF
--- a/tpl/github.class.phtml
+++ b/tpl/github.class.phtml
@@ -55,7 +55,7 @@
 
 <?= $info->shortDescription ?> 
 
-<?= str_replace("\n", "  \n", $info->longDescription) ?> 
+<?= str_replace("\n", "  \n", (string)$info->longDescription) ?> 
 
 **Parameters**
 


### PR DESCRIPTION
If no `longDescription`, `null` is passed to `str_replace()`, which is deprecated now in PHP 8.

Casting value to string to avoid the E_DEPRECATED.